### PR TITLE
Added beta t3 chat

### DIFF
--- a/src/bang.ts
+++ b/src/bang.ts
@@ -11,6 +11,15 @@ export const bangs = [
     u: "https://www.t3.chat/new?q={{{s}}}",
   },
   {
+    c: "AI",
+    d: "www.beta.t3.chat",
+    r: 0,
+    s: "T3 Chat",
+    sc: "AI",
+    t: "bt3",
+    u: "https://www.beta.t3.chat/new?q={{{s}}}",
+  },
+  {
     c: "Tech",
     d: "www.01net.com",
     r: 4,


### PR DESCRIPTION
## Description

This pull request introduces a new bang command, `!bt3`. This new bang provides users with a quick and convenient way to access the beta version of the T3 Chat service directly from the search bar.

## Changes Included

*   Registered `!bt3` as a new bang command.
*   Configured the `!bt3` bang to redirect users to the specified URL for the T3 Chat beta environment.
*   Ensured that any query appended after `!bt3` (e.g., `!bt3 how does this work?`) is correctly passed along to the T3 Chat service, if applicable by its design.